### PR TITLE
Added a install.sh script to make installation easier for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ ydlidar_ros2_driver is a new ros package, which is designed to gradually become 
 ## How to Create a ROS2 workspace
 [Create a workspace](https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/#create-a-workspace)
 
+# Script Install:
+Open Terminal and execute :
+```
+curl -o install.sh https://raw.githubusercontent.com/karanS08/ydlidar_ros2_driver/master/install.sh
+chmod +x install.sh
+./install.sh
+```
+
+# Manual Install:
 
 ## Compile & Install YDLidar SDK
 
@@ -63,6 +72,7 @@ ydlidar_ros2_driver depends on YDLidar-SDK library. If you have never installed 
 	$sudo sh src/ydlidar_ros2_driver/startup/initenv.sh
     ```
     Note: After completing the previous operation, replug the LiDAR again.
+
 	
 ## Configure LiDAR
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+function run_command() {
+    echo "Running: $1"
+    eval $1
+    if [ $? -ne 0 ]; then
+        echo "Error executing: $1"
+        exit 1
+    fi
+    echo "Command executed successfully."
+    echo
+}
+
+echo "Starting YDLidar ROS2 Driver Installation..."
+
+# Step 1: Create Workspace Directory
+run_command "mkdir ~/ydlidar_ws"
+run_command "cd ~/ydlidar_ws"
+
+# Step 2: Clone YDLidar SDK Repository
+run_command "git clone https://github.com/YDLIDAR/YDLidar-SDK.git"
+run_command "cd YDLidar-SDK"
+
+# Step 3: Build and Install YDLidar SDK
+run_command "mkdir build"
+run_command "cd build"
+run_command "cmake .."
+run_command "make"
+run_command "sudo make install"
+run_command "cd .."
+run_command "pip install ."
+run_command "cd build"
+# run_command "cpack"
+run_command "cd ~/"
+
+# Step 4: Clone YDLidar ROS2 Driver Repository
+run_command "mkdir ~/ydlidar_ws/src"
+run_command "cd ~/ydlidar_ws/src"
+run_command "git clone https://github.com/cclngit/ydlidar_ros2_driver.git"
+
+# Step 5: Build ROS2 Packages
+run_command "cd ~/ydlidar_ws"
+run_command "colcon build --symlink-install"
+run_command "colcon build --symlink-install"
+
+run_command "source ./install/setup.bash"
+
+# Step 6: Set Up Environment Variables
+run_command "echo 'source ~/ydlidar_ws/install/setup.bash' >> ~/.bashrc"
+run_command "source ~/.bashrc"
+
+# Step 7: Grant Execute Permissions to Startup Scripts
+run_command "chmod 0777 src/ydlidar_ros2_driver/startup/*"
+
+# Step 8: Run Initialization Script
+run_command "sudo sh src/ydlidar_ros2_driver/startup/initenv.sh"
+
+echo "YDLidar ROS2 Driver Installation Completed."

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@ function run_command() {
 
 echo "Starting YDLidar ROS2 Driver Installation..."
 
+# Check for colcon 
+if ! command -v colcon &> /dev/null; then
+    run_command "sudo apt install python3-colcon-common-extensions"
+fi
+
 # Step 1: Create Workspace Directory
 run_command "mkdir ~/ydlidar_ws"
 run_command "cd ~/ydlidar_ws"


### PR DESCRIPTION
Based on the problems I faced while installing the code , I have compiled a bash script for Linux users to install the Ydlidar-SDK and ROS2 drivers with simply one terminal script. 

Please change the :
```curl -o install.sh https://raw.githubusercontent.com/karanS08/ydlidar_ros2_driver/master/install.sh```
in the README.md file to the correct link of the parent directory.
